### PR TITLE
Hydrate a package xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,24 @@ The only missing piece from the resulting scratch org is the features list. I'm 
 Run the command:
 
 ```
-$ sfdx hydrate:scratchfile -u <username|alias>`
+$ sfdx hydrate:scratchfile -u {username|alias} > project-scratch-def.json
 ```
 
-This will produce a JSON string in the command line that can be copied to a scratch org file.
+This will produce a scratch definition and pipe it into the project-scratch-def.json file.
 
-example output:
+## Creating a complete package.xml from a source org
+
+When migrating to an SFDX project, I find starting with a complete package.xml, and then trimming undesirable metadata elements until I have a working project is a good approach.
+
+This addition to the hydrate tool will generate that complete package.xml.
+
+Run the command:
 
 ```
-{
-  "orgName": "Wayne Enterprises",
-  "edition": "Enterprise",
-  "description": "Created by the sfdx-hydrate plugin",
-  "features": [],
-  "orgPreferences": {
-    "enabled": [
-      "IsCascadeActivateToRelatedPricesEnabled",
-      "IsQuantityScheduleEnabled",
-      "IsRevenueScheduleEnabled",
-      "IsQuoteEnabled",
-      ... 
-    ],
-    "disabled": [
-      "IsMiddleNameEnabled",
-      "IsNameSuffixEnabled",
-      "IsMarketingActionEnabled",
-      "IsNegativeQuantityEnabled",
-      ...
-    ]
-  }
-}
+$ sfdx hydrate:scratchfile -u {username|alias} > package.xml
 ```
+
+This will produce an XML string, and pipe it directly into the file called package.xml.
 
 ### Install as plugin
 

--- a/commands/hydratePackagexml.js
+++ b/commands/hydratePackagexml.js
@@ -1,0 +1,123 @@
+const forceUtils = require('../lib/forceUtils.js');
+
+(function () {
+  'use strict';
+  
+  module.exports = {
+    topic: 'hydrate',
+    command: 'packagexml',
+    description: 'Generate a complete package xml form the specified org',
+    help: 'help text for hydrate:packagexml:create',
+    flags: [
+      {
+        name: 'username',
+        char: 'u',
+        description: 'org that the package will be based on',
+        hasValue: true,
+        required: false
+      }
+    ],
+    run(context) {
+
+      const username = context.flags.username;
+      const apiVersion = '42.0';
+
+      const packageXml = {
+        types: {},
+        version: apiVersion
+      };
+      
+      forceUtils.getOrg(username, (org) => {
+
+        const connPromise = org.force._getConnection(org, org.config);
+
+        const describePromise = connPromise.then((conn) => {
+          return conn.metadata.describe(apiVersion);
+        });
+
+        const foldersPromise = Promise.all([connPromise, describePromise]).then((params) => {
+          const conn = params[0];
+          const describe = params[1];
+
+          const folderPromises = [];
+
+          describe.metadataObjects.forEach((object) => {
+            if (object.inFolder) {
+              const objectType = object.xmlName.replace('Template', '');
+              const promise = conn.metadata.list({ type: `${objectType}Folder`, folder: null }, apiVersion)
+              folderPromises.push(promise);
+            }
+          });
+
+          return Promise.all(folderPromises);
+        });
+
+        const folderedObjectsPromise = Promise.all([connPromise, foldersPromise]).then((params) => {
+          const conn = params[0];
+          const folders = params[1];
+
+          const folderedObjectPromises = [];
+
+          folders.forEach((folder) => {
+            try {
+              let objectType = folder.type.replace('Folder', '');
+              if (objectType === 'Email') {
+                objectType += 'Template';
+              }
+              const promise = conn.metadata.list({ type: objectType, folder: folder.fullName }, apiVersion);
+              folderedObjectPromises.push(promise);
+            } catch (exception) {}
+          });
+
+          return folderedObjectPromises;
+        });
+
+        const unfolderedObjectsPromise = Promise.all([connPromise, describePromise]).then((params) => {
+          const conn = params[0];
+          const describe = params[1];
+
+          const unfolderedObjectPromises = [];
+
+          describe.metadataObjects.forEach((object) => {
+            if (!object.inFolder && object.xmlName !== 'StandardValueSetTranslation') {
+              const promise = conn.metadata.list({ type: object.xmlName, folder: null }, apiVersion);
+              unfolderedObjectPromises.push(promise);
+            }
+          });
+
+          return Promise.all(unfolderedObjectPromises);
+        });
+
+        Promise.all([unfolderedObjectsPromise, folderedObjectsPromise]).then((params) => {
+          const unfolderedObjects = params[0];
+          const folderedObjects = params[1];
+
+          unfolderedObjects.forEach((unfolderedObject) => {
+            try {
+              unfolderedObject.forEach((metadataEntry) => {
+                if (!packageXml.types[metadataEntry.type]) {
+                  packageXml.types[metadataEntry.type] = [];
+                }
+                packageXml.types[metadataEntry.type].push(metadataEntry.fullName);
+              });
+            } catch (exception) {}
+          });
+
+          folderedObjects.forEach((folderedObject) => {
+            try {
+              folderedObject.forEach((metadataEntry) => {
+                if (!packageXml.types[metadataEntry.type]) {
+                  packageXml.types[metadataEntry.type] = [];
+                }
+                packageXml.types[metadataEntry.type].push(metadataEntry.fullName);
+              });
+            } catch (exception) {}
+          });
+
+          console.log(JSON.stringify(packageXml, null, '    '));
+        });
+
+      });
+    }
+  };
+}());

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const hydrateScratchfile = require('./commands/hydrateScratchfile.js');
+const hydratePackagexml = require('./commands/hydratePackagexml.js');
 
 (function () {
   'use strict';
@@ -9,6 +10,7 @@ const hydrateScratchfile = require('./commands/hydrateScratchfile.js');
   }];
 
   exports.commands = [
-    hydrateScratchfile
+    hydrateScratchfile,
+    hydratePackagexml
   ];
 }());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "sfdx-rumble",
-  "version": "0.1.0",
+  "name": "sfdx-hydrate",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2712,6 +2712,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "x2js": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/x2js/-/x2js-3.1.1.tgz",
+      "integrity": "sha1-98TmB3wpRw8rDdZxSAWHGyVmcRk=",
+      "requires": {
+        "xmldom": "0.1.22"
+      }
     },
     "xml2js": {
       "version": "0.4.17",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "sfdx-js": "^4.0.5",
     "jsforce": "^1.7.1",
-    "salesforce-alm": "^40.0.6"
+    "salesforce-alm": "^40.0.6",
+    "sfdx-js": "^4.0.5",
+    "x2js": "^3.1.1"
   },
   "devDependencies": {
     "eslint": "^3.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,6 +2929,12 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+x2js@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/x2js/-/x2js-3.1.1.tgz#f7c4e6077c29470f2b0dd6714805871b25667119"
+  dependencies:
+    xmldom "^0.1.19"
+
 xml2js@0.4.17:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
@@ -2956,6 +2962,10 @@ xmlbuilder@~9.0.1:
 xmldom@0.1.22:
   version "0.1.22"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.22.tgz#10de4e5e964981f03c8cc72fadc08d14b6c3aa26"
+
+xmldom@^0.1.19:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
When migrating to an SFDX project, I find starting with a complete package.xml, and then trimming undesirable metadata elements until I have a working project is a good approach.

This addition to the hydrate tool will generate that complete packagexml for me.

To use it, pipe the output to a file like so

```
sfdx hydrate:packagexml -u orgname > package.xml
```