### PR TITLE
Quickfilters and API Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ $ sfdx hydrate:packagexml -u {username|alias} > package.xml
 
 This will produce an XML string, and pipe it directly into the file called package.xml.
 
+#### Optional Parameters
+|Parameter|Description|
+|---|---|
+|-a, --api|Set the API version of the packagexml file (Default is 42.0)|
+|-q, --quickfilter|Set of [predefined lists](./assets/quickFilters.json) to help only pull metadata types you really need|
+
+Using the Reporting quick filter will only output items from Reports, Dashboards, and Report Types. <br/>From assets/quickFilters.json:
+```javascript
+    "Reporting": ["Report",
+        "Dashboard",
+        "ReportType"
+    ]
+```
+
+```
+$ sfdx hydrate:packagexml -u {username|alias} -a 40.0 -q Reporting > package.xml
+```
+
+
+
 ### Install as plugin
 
 1. Install plugin: `sfdx plugins:install sfdx-hydrate`

--- a/assets/quickFilters.json
+++ b/assets/quickFilters.json
@@ -1,0 +1,22 @@
+{
+    "Reporting": ["Report",
+        "Dashboard",
+        "ReportType"
+    ],
+    "Automation": ["Flow",
+        "FlowDefinition",
+        "Workflow",
+        "ApexClass",
+        "ApexTrigger",
+        "ApexComponent",
+        "ApexPage"
+    ],
+    "Security": ["PermissionSet",
+        "Profile",
+        "ProfilePasswordPolicy",
+        "ProfileSessionSetting",
+        "RemoteSiteSetting",
+        "SharingRules",
+        "ConnectedApp"
+    ]
+}

--- a/commands/hydratePackagexml.js
+++ b/commands/hydratePackagexml.js
@@ -1,5 +1,6 @@
 const forceUtils = require('../lib/forceUtils.js');
 const X2JS = require('x2js');
+const quickFilters = require('../assets/quickFilters.json');
 
 (function () {
   'use strict';
@@ -16,12 +17,27 @@ const X2JS = require('x2js');
         description: 'org that the package will be based on',
         hasValue: true,
         required: false
+      },
+      {
+        name: 'quickfilter',
+        char: 'q',
+        description: 'a predefined set of metadata types',
+        hasValue: true,
+        required: false
+      },
+      {
+        name: 'api',
+        char: 'a',
+        description: 'API Version',
+        hasValue: true,
+        required: false
       }
     ],
     run(context) {
 
       const username = context.flags.username;
-      const apiVersion = '42.0';
+      const apiVersion = context.flags.api || '42.0';
+      const quickFilter = context.flags.quickfilter;
 
       let packageTypes = {};
       
@@ -123,7 +139,9 @@ const X2JS = require('x2js');
           };
 
           Object.keys(packageTypes).forEach((type) => {
-            packageJson.types.push({ name: type, members: packageTypes[type] });
+            if(!quickFilter||quickFilters[quickFilter].includes(type)){
+              packageJson.types.push({ name: type, members: packageTypes[type] });
+            }
           });
 
           const packageXml = `<?xml version="1.0" encoding="UTF-8"?><Package xmlns="http://soap.sforce.com/2006/04/metadata">${new X2JS().js2xml(packageJson)}</Package>`;


### PR DESCRIPTION
@loganm love the plugin, thanks for putting this together!

I'm a Salesforce consultant where this comes in really handy for quickly getting at a client's metadata. I thought it would be great if we had an options to specify some common set of metadata types for easy fetching using sfdx. If you don't specify the parameter, it will return everything like before.

I also added the ability to specify the API version in the request. Again, default is to the hardcoded 42.0.

Note: I did NOT increment the package version number. I figured you would do that when you were ready.